### PR TITLE
docs: StoryBook 格式从CSF2改变到CSF

### DIFF
--- a/packages/docs/storybook/.storybook/main.ts
+++ b/packages/docs/storybook/.storybook/main.ts
@@ -3,7 +3,10 @@ import { mergeConfig } from 'vite'
 import { fileURLToPath, URL } from 'node:url'
 
 const config: StorybookConfig = {
-  stories: ['../stories/**/*.mdx', '../stories/**/*.stories.@(js|jsx|mjs|ts|tsx)'],
+  stories: [
+    '../stories/**/*.mdx',
+    '../stories/**/*.stories.@(js|jsx|mjs|ts|tsx)'
+  ],
   addons: [
     '@storybook/addon-essentials',
     '@storybook/addon-onboarding',
@@ -11,13 +14,17 @@ const config: StorybookConfig = {
   ],
   framework: {
     name: '@storybook/vue3-vite',
-    options: {}
+    options: {
+      // docgen: 'vue-component-meta'
+    }
   },
-  async viteFinal(config) { 
+  async viteFinal(config) {
     return mergeConfig(config, {
       resolve: {
         alias: {
-          '@pixel-ui/components': fileURLToPath(new URL('../../../components', import.meta.url))
+          '@pixel-ui/components': fileURLToPath(
+            new URL('../../../components', import.meta.url)
+          )
         }
       },
       define: {

--- a/packages/docs/storybook/problem/在网页中保存报错，解决后禁用保存功能.md
+++ b/packages/docs/storybook/problem/在网页中保存报错，解决后禁用保存功能.md
@@ -1,0 +1,25 @@
+## 保存报错
+
+报错为
+`Error writing to ./stories/Alert/Alert.stories.ts:
+Error: Updating a CSF2 story is not supported`
+
+CSF2写法不支持
+
+找到csf2写法是什么，使用csf3写法解决无法保存问题。
+
+在CSF2中代码格式为
+
+```tsx
+export const Primary: ComponentStory<typeof Button> = (args) => (
+  <Button {...args} />
+)
+Primary.args = { primary: true }
+```
+
+在csf3中代码格式为
+
+```tsx
+type Story = StoryObj<typeof meta>
+export const Primary: Story = { args: { primary: true } }
+```

--- a/packages/docs/storybook/stories/Alert/Alert.stories.ts
+++ b/packages/docs/storybook/stories/Alert/Alert.stories.ts
@@ -1,8 +1,10 @@
-import type { Meta, StoryFn } from '@storybook/vue3'
+import type { Meta, StoryObj } from '@storybook/vue3'
 
-// import { PxAlert } from '@mmt817/pixel-ui'
+// import { type AlertProps } from '@mmt817/pixel-ui'
 import { PxAlert, type AlertProps } from '@pixel-ui/components'
 import '@mmt817/pixel-ui/dist/theme/Alert.css'
+// import { render } from 'vue'
+// import { render } from 'vue'
 
 const meta: Meta<typeof PxAlert> = {
   title: 'Feedback/Alert',
@@ -25,89 +27,110 @@ const meta: Meta<typeof PxAlert> = {
     },
     showIcon: {
       control: { type: 'boolean' }
+    },
+    iron: {
+      control: { type: 'boolean' }
     }
   }
 }
 
 export default meta
 
-const Template: StoryFn<typeof PxAlert> = (args: AlertProps) => ({
-  components: { PxAlert },
-  setup() {
-    return { args }
-  },
-  template: `
+type Story = StoryObj<typeof meta>
+
+const Template = (args: AlertProps) => {
+  return {
+    components: { PxAlert },
+    setup() {
+      return { args }
+    },
+    template: `
     <px-alert v-bind="args">
-      这是一个提示框组件！
+      <template v-if="args.slots?.default">
+        <component :is="args.slots.default">
+      </template>
+      <template v-else>
+        {{args.description}}
+      </template>
     </px-alert>
   `
-})
-
-export const Default = Template.bind({})
-Default.args = {
-  title: '默认提示',
-  type: 'info',
-  description: '',
-  effect: 'light',
-  closable: true,
-  showIcon: true,
-  center: false
+  }
 }
 
-export const WithDescription: StoryFn<typeof PxAlert> = (args: AlertProps) => ({
-  components: { PxAlert },
-  setup() {
-    return { args }
+export const Default: Story = {
+  args: {
+    title: '默认提示',
+    type: 'info',
+    description: '这是description中的内容, 用以比较和slots的优先级',
+    effect: 'light',
+    closable: true,
+    showIcon: true,
+    center: false,
+    slots: {
+      default: {
+        template: `这是slots中的内容, 用以比较和description的优先级`
+      }
+    }
   },
-  template: `
-    <px-alert v-bind="args">
-      这是一个带描述的提示框内容，适用于更复杂的提示信息。
-    </px-alert>
-  `
-})
-WithDescription.args = {
-  title: '提示标题',
-  type: 'success',
-  closable: true,
-  showIcon: true,
-  effect: 'light'
+  render: Template
 }
 
-export const DarkEffect = Template.bind({})
-DarkEffect.args = {
-  title: '暗色提示框',
-  type: 'danger',
-  effect: 'dark',
-  description: 'CSS Houdini 特效也支持深色模式。',
-  closable: true,
-  showIcon: true
-}
-
-export const Centered = Template.bind({})
-Centered.args = {
-  title: '居中提示',
-  description: '内容与标题均居中显示。',
-  center: true,
-  showIcon: false,
-  closable: true,
-  type: 'warning'
-}
-
-export const NonClosable = Template.bind({})
-NonClosable.args = {
-  title: '不可关闭',
-  description: '该提示框无法通过点击关闭图标来关闭。',
-  closable: false,
-  type: 'info',
-  showIcon: true
-}
-
-export const Types: StoryFn<typeof PxAlert> = (args: AlertProps) => ({
-  components: { PxAlert },
-  setup() {
-    return { args }
+export const WithDescription: Story = {
+  args: {
+    title: '提示标题',
+    type: 'success',
+    closable: true,
+    showIcon: true,
+    effect: 'light',
+    description: '这是一个带描述的提示框内容，适用于更复杂的提示信息'
   },
-  template: `
+  paramters: {},
+  render: Template
+}
+
+export const DarkEffect: Story = {
+  args: {
+    title: '暗色提示框',
+    type: 'danger',
+    effect: 'dark',
+    description: 'CSS Houdini 特效也支持深色模式。',
+    closable: true,
+    showIcon: true
+  },
+  render: Template
+}
+
+export const Centered: Story = {
+  args: {
+    title: '居中提示',
+    description: '内容与标题均居中显示。',
+    center: true,
+    showIcon: false,
+    closable: true,
+    type: 'warning'
+  },
+  render: Template
+}
+
+export const NonCloseable: Story = {
+  args: {
+    title: '不可关闭',
+    description: '该提示框无法通过点击关闭图标来关闭。',
+    closable: false,
+    type: 'info',
+    showIcon: true
+  },
+  render: Template
+}
+
+export const Types: Story = {
+  args: {},
+  render: (args: AlertProps) => ({
+    components: { PxAlert },
+    setup() {
+      return { args }
+    },
+    template: `
     <px-alert v-bind="args" title="Success alert" type="success" />
     <px-alert v-bind="args" title="Info alert" type="info" />
     <px-alert v-bind="args" title="Warning alert" type="warning" />
@@ -115,4 +138,5 @@ export const Types: StoryFn<typeof PxAlert> = (args: AlertProps) => ({
     <px-alert v-bind="args" title="Sakura alert" type="sakura" />
     <px-alert v-bind="args" title="Iron alert" iron />
   `
-})
+  })
+}

--- a/packages/docs/storybook/stories/AnimationFrame/AnimationFrame.stories.ts
+++ b/packages/docs/storybook/stories/AnimationFrame/AnimationFrame.stories.ts
@@ -1,7 +1,10 @@
-import type { Meta, StoryFn } from '@storybook/vue3'
+import type { Meta, StoryObj } from '@storybook/vue3'
 
 // import { PxAnimationFrame } from '@mmt817/pixel-ui'
-import { PxAnimationFrame } from '@pixel-ui/components'
+import {
+  PxAnimationFrame,
+  type AnimationFrameProps
+} from '@pixel-ui/components'
 import '@mmt817/pixel-ui/dist/theme/AnimationFrame.css'
 
 const meta: Meta<typeof PxAnimationFrame> = {
@@ -34,15 +37,12 @@ const meta: Meta<typeof PxAnimationFrame> = {
 
 export default meta
 
-const Naloong = '../assets/images/pet.gif'
-const twoking = '../assets/images/twoking.gif'
-const taffy = '../assets/images/taffy.gif'
+type Story = StoryObj<typeof meta>
 
-const Template: StoryFn = (args, { argTypes }) => ({
+const Template = (args: AnimationFrameProps) => ({
   setup: () => ({ args }),
-  props: Object.keys(argTypes),
   components: { PxAnimationFrame },
-  template: `
+  template: `  
     <div class="container" style="width: 100%; height: 400px; display: flex; justify-content: center; align-items: center;">
       <px-animation-frame
         v-bind="args"
@@ -56,30 +56,39 @@ const Template: StoryFn = (args, { argTypes }) => ({
     }
   }
 })
+const Naloong = '../assets/images/pet.gif'
+const twoking = '../assets/images/twoking.gif'
+const taffy = '../assets/images/taffy.gif'
 
-export const Default = Template.bind({})
-Default.args = {
-  src: twoking,
-  stages: [{ type: 'loop', start: 0, end: 6 }]
+export const Default: Story = {
+  args: {
+    src: twoking,
+    stages: [{ type: 'loop', start: 0, end: 6 }]
+  },
+  render: Template
 }
 
-export const Loop = Template.bind({})
-Loop.args = {
-  src: taffy,
-  loop: true,
-  width: 320,
-  height: 320
+export const Loop: Story = {
+  args: {
+    src: taffy,
+    loop: true,
+    width: 320,
+    height: 320
+  },
+  render: Template
 }
 
-export const Henshin = Template.bind({})
-Henshin.args = {
-  src: Naloong,
-  width: 320,
-  height: 320,
-  stages: [
-    { type: 'loop', start: 0, end: 11 },
-    { type: 'once', start: 12, end: 41 },
-    { type: 'loop', start: 31, end: 41 },
-    { type: 'once', start: 42, end: 52 }
-  ]
+export const Henshin: Story = {
+  args: {
+    src: Naloong,
+    width: 320,
+    height: 320,
+    stages: [
+      { type: 'loop', start: 0, end: 11 },
+      { type: 'once', start: 12, end: 41 },
+      { type: 'loop', start: 31, end: 41 },
+      { type: 'once', start: 42, end: 52 }
+    ]
+  },
+  render: Template
 }

--- a/packages/docs/storybook/stories/Badge/Badge.stories.ts
+++ b/packages/docs/storybook/stories/Badge/Badge.stories.ts
@@ -1,6 +1,6 @@
-import type { Meta, StoryFn } from '@storybook/vue3'
+import type { Meta, StoryObj } from '@storybook/vue3'
 
-import { PxBadge } from '@pixel-ui/components'
+import { PxBadge, type BadgeProps } from '@pixel-ui/components'
 import { PxButton, PxIcon } from '@mmt817/pixel-ui'
 import '@mmt817/pixel-ui/dist/theme/Badge.css'
 import '@mmt817/pixel-ui/dist/theme/Button.css'
@@ -54,7 +54,9 @@ const meta: Meta<typeof PxBadge> = {
 
 export default meta
 
-const Template: StoryFn = (args) => ({
+type Story = StoryObj<typeof meta>
+
+const Template = (args: BadgeProps) => ({
   components: { PxBadge, PxButton },
   setup() {
     return { args }
@@ -68,17 +70,74 @@ const Template: StoryFn = (args) => ({
   `
 })
 
-export const Default = Template.bind({})
-Default.args = {
-  value: '5'
+export const Default: Story = {
+  args: {
+    value: '5'
+  },
+  render: Template
 }
 
-export const Types: StoryFn = (args) => ({
-  components: { PxBadge, PxButton },
-  setup() {
-    return { args }
+export const Max: Story = {
+  args: {
+    value: 100,
+    max: 9
   },
-  template: `
+  render: Template
+}
+
+export const Dot: Story = {
+  args: {
+    isDot: true
+  },
+  render: Template
+}
+
+export const custom: Story = {
+  args: {
+    value: '5',
+    color: '#626aef'
+  },
+  render: Template
+}
+
+export const Offset: Story = {
+  args: {
+    value: '5',
+    offset: [10, 5]
+  },
+  render: Template
+}
+
+export const withSlot: Story = {
+  render: (args: BadgeProps) => ({
+    components: { PxBadge, PxButton, PxIcon },
+    setup() {
+      return { args }
+    },
+    template: `
+        <px-badge value = "99" class="item" color = "#626aef" >
+          <px-button>SLOT</px-button>
+          <template #content = "{ value }" >
+            <div class="custom-content">
+              <px-icon icon="cog" size="20" color="white" />
+              <span>{{ value }}</span>
+            </div>
+          </template>
+        </px-badge>
+      `
+  })
+}
+
+export const Types: Story = {
+  args: {
+    value: '5'
+  },
+  render: (args: BadgeProps) => ({
+    components: { PxBadge, PxButton },
+    setup() {
+      return { args }
+    },
+    template: `
     <div class="px-badge-container" style="display: flex; gap: 10px;">
       <px-badge v-bind="args">
         <px-button>Badge</px-button>
@@ -100,48 +159,5 @@ export const Types: StoryFn = (args) => ({
       </px-badge>
     </div>
   `
-})
-Types.args = {
-  value: '5'
+  })
 }
-
-export const Max = Template.bind({})
-Max.args = {
-  value: 100,
-  max: 9
-}
-
-export const Dot = Template.bind({})
-Dot.args = {
-  isDot: true
-}
-
-export const custom = Template.bind({})
-custom.args = {
-  value: '5',
-  color: '#626aef'
-}
-
-export const Offset = Template.bind({})
-Offset.args = {
-  value: '5',
-  offset: [10, 5]
-}
-
-export const withSlot: StoryFn = (args) => ({
-  components: { PxBadge, PxButton, PxIcon },
-  setup() {
-    return { args }
-  },
-  template: `
-    <px-badge value = "99" class="item" color = "#626aef" >
-      <px-button>SLOT</px-button>
-      <template #content = "{ value }" >
-        <div class="custom-content">
-          <px-icon icon="cog" size="20" color="white" />
-          <span>{{ value }}</span>
-        </div>
-      </template>
-    </px-badge>
-  `
-})

--- a/packages/docs/storybook/stories/Button/Button.stories.ts
+++ b/packages/docs/storybook/stories/Button/Button.stories.ts
@@ -1,10 +1,12 @@
-import type { StoryFn, ArgTypes, StoryObj, Meta } from '@storybook/vue3'
+import type { ArgTypes, StoryObj, Meta } from '@storybook/vue3'
 import { fn, within, userEvent, expect } from '@storybook/test'
 import { action } from '@storybook/addon-actions'
 
 // import { PxButton, PxButtonGroup } from '@mmt817/pixel-ui'
-import { PxButton, PxButtonGroup } from '@pixel-ui/components'
+import { PxButton, PxButtonGroup, type ButtonProps } from '@pixel-ui/components'
 import '@mmt817/pixel-ui/dist/theme/Button.css'
+
+// type a =  ComponentProps(typeof PxButton)
 
 const meta: Meta<typeof PxButton> = {
   title: 'Basic/Button',
@@ -91,19 +93,19 @@ const methods = {
   onClick: action('onClick')
 }
 
-const Template: StoryFn = (args, { argTypes }) => ({
-  setup: () => ({ args }),
-  props: Object.keys(argTypes),
-  components: { PxButton },
-  template: '<px-button v-bind="args" @click="onClick" />',
-  methods
-})
-export const Button = Template.bind({})
-Button.args = {
-  type: 'base',
-  label: 'Button'
+export const Button: Story = {
+  args: {
+    type: 'base',
+    label: 'Button'
+  },
+  render: (args: ButtonProps) => ({
+    setup: () => ({ args }),
+    components: { PxButton },
+    template: '<px-button v-bind="args" @click="onClick" />',
+    methods
+  })
 }
-const AllSizesTemplate: StoryFn = (args, { argTypes }) => ({
+const AllSizesTemplate = (args: ButtonProps, { argTypes }: ArgTypes) => ({
   setup: () => ({ args }),
   props: Object.keys(argTypes),
   components: {
@@ -128,7 +130,58 @@ const AllSizesTemplate: StoryFn = (args, { argTypes }) => ({
   methods
 })
 
-const AllColorsAndSizesTemplate: StoryFn = (args, { argTypes }) => ({
+export const Primary: Story = {
+  args: {
+    type: 'primary',
+    label: 'Primary'
+  },
+  render: AllSizesTemplate
+}
+
+export const Success: Story = {
+  args: {
+    type: 'success',
+    label: 'Success'
+  },
+  render: AllSizesTemplate
+}
+
+export const Warning: Story = {
+  args: {
+    type: 'warning',
+    label: 'Warning'
+  },
+  render: AllSizesTemplate
+}
+
+export const Danger: Story = {
+  args: {
+    type: 'danger',
+    label: 'Danger'
+  },
+  render: AllSizesTemplate
+}
+
+export const Sakura: Story = {
+  args: {
+    type: 'sakura',
+    label: 'Sakura'
+  },
+  render: AllSizesTemplate
+}
+
+export const WithIcon: Story = {
+  args: {
+    label: 'Button',
+    icon: 'search'
+  },
+  render: AllSizesTemplate
+}
+
+const AllColorsAndSizesTemplate = (
+  args: ButtonProps,
+  { argTypes }: ArgTypes
+) => ({
   setup: () => ({ args }),
   props: Object.keys(argTypes),
   components: {
@@ -158,46 +211,12 @@ const AllColorsAndSizesTemplate: StoryFn = (args, { argTypes }) => ({
   methods
 })
 
-export const Primary = AllSizesTemplate.bind({})
-Primary.args = {
-  type: 'primary',
-  label: 'Primary'
-}
-
-export const Success = AllSizesTemplate.bind({})
-Success.args = {
-  type: 'success',
-  label: 'Success'
-}
-
-export const Warning = AllSizesTemplate.bind({})
-Warning.args = {
-  type: 'warning',
-  label: 'Warning'
-}
-
-export const Danger = AllSizesTemplate.bind({})
-Danger.args = {
-  type: 'danger',
-  label: 'Danger'
-}
-
-export const Sakura = AllSizesTemplate.bind({})
-Sakura.args = {
-  type: 'sakura',
-  label: 'Sakura'
-}
-
-export const WithIcon = AllSizesTemplate.bind({})
-WithIcon.args = {
-  label: 'Button',
-  icon: 'search'
-}
-
-export const Square = AllColorsAndSizesTemplate.bind({})
-Square.args = {
-  label: '817',
-  square: true
+export const Square: Story = {
+  args: {
+    label: '817',
+    square: 'true'
+  },
+  render: AllColorsAndSizesTemplate
 }
 
 // ButtonGroup
@@ -205,7 +224,7 @@ export const Group: Story & { args: { content1: string; content2: string } } = {
   argTypes: {
     groupType: {
       control: { type: 'select' },
-      options: ['primary', 'success', 'warning', 'danger', 'base', '']
+      options: ['primary', 'success', 'warning', 'danger', 'base']
     },
     groupSize: {
       control: { type: 'select' },

--- a/packages/docs/storybook/stories/Card/Card.stories.ts
+++ b/packages/docs/storybook/stories/Card/Card.stories.ts
@@ -1,6 +1,6 @@
-import type { Meta, StoryFn } from '@storybook/vue3'
+import type { ArgTypes, Meta, StoryObj } from '@storybook/vue3'
 
-import { PxCard } from '@pixel-ui/components'
+import { PxCard, type CardProps } from '@pixel-ui/components'
 import { PxButton, PxIcon, PxText } from '@mmt817/pixel-ui'
 import '@mmt817/pixel-ui/dist/theme/Card.css'
 
@@ -29,8 +29,9 @@ const meta: Meta<typeof PxCard> = {
 }
 
 export default meta
+type Story = StoryObj<typeof meta>
 
-export const Default: StoryFn = (args, { argTypes }) => ({
+const Template = (args: CardProps, { argTypes }: ArgTypes) => ({
   setup: () => ({ args }),
   props: Object.keys(argTypes),
   components: {
@@ -40,93 +41,91 @@ export const Default: StoryFn = (args, { argTypes }) => ({
     '<px-card v-bind="args" style="width: 80%">This is a card.</px-card>'
 })
 
-export const Hoverable: StoryFn = (args, { argTypes }) => ({
-  setup: () => ({ args }),
-  props: Object.keys(argTypes),
-  components: {
-    PxCard,
-    PxText,
-    PxIcon
+export const Default: Story = {
+  render: Template
+}
+export const Round: Story = {
+  args: {
+    round: true
   },
-  template: `<px-card v-bind="args" style="width: 140px; text-align: center">
-    <template #header>
-      <div style="width: 100%; display: flex; justify-content: center; align-items: center; margin-bottom: 10px">
-        <px-icon icon="plus-solid" size="20"></px-icon>
-      </div>
-    </template>
-    <px-text>Add</px-text>
-  </px-card>`
-})
-
-Hoverable.args = {
-  hoverable: true
+  render: Template
+}
+export const Circle: Story = {
+  args: {
+    circle: true
+  },
+  render: Template
 }
 
-export const WithSlots: StoryFn = (args, { argTypes }) => ({
-  setup: () => ({ args }),
-  props: Object.keys(argTypes),
-  components: {
-    PxCard,
-    PxButton,
-    PxIcon,
-    PxText
+export const Hoverable: Story = {
+  args: {
+    hoverable: true
   },
-  template: `<px-card v-bind="args" style="width: 80%">
-		<template #prepend>
-			<px-icon icon="check-solid" size="20" color="#ff6f5c" />
-		</template>
-		<template #header>
-			<strong>Card header</strong>
-		</template>
-		<px-text color="#4d6bfe" size="14">
-			This is the card body.
-		</px-text>
-		<template #footer>
-			<px-text size="16">
-				Card footer
-			</px-text>
-		</template>
-		<template #append>
-			<px-button type="success">Click me</px-button>
-		</template>
-	</px-card>`
-})
-
-export const Round: StoryFn = (args, { argTypes }) => ({
-  setup: () => ({ args }),
-  props: Object.keys(argTypes),
-  components: {
-    PxCard
-  },
-  template: `<px-card v-bind="args" style="width: 80%">This is a card.</px-card>`
-})
-Round.args = {
-  round: true
+  render: (args: CardProps, { argTypes }: ArgTypes) => ({
+    setup: () => ({ args }),
+    props: Object.keys(argTypes),
+    components: {
+      PxCard,
+      PxText,
+      PxIcon
+    },
+    template: `
+      <px-card v-bind="args" style="width: 140px; text-align: center">
+        <template #header>
+          <div style="width: 100%; display: flex; justify-content: center; align-items: center; margin-bottom: 10px">
+            <px-icon icon="plus-solid" size="20"></px-icon>
+          </div>
+        </template>
+        <px-text>Add</px-text>
+      </px-card>`
+  })
 }
 
-export const Circle: StoryFn = (args, { argTypes }) => ({
-  setup: () => ({ args }),
-  props: Object.keys(argTypes),
-  components: {
-    PxCard
-  },
-  template: `<px-card v-bind="args" style="width: 80%">This is a card.</px-card>`
-})
-Circle.args = {
-  circle: true
+export const WithSlots: Story = {
+  render: (args, { argTypes }) => ({
+    setup: () => ({ args }),
+    props: Object.keys(argTypes),
+    components: {
+      PxCard,
+      PxButton,
+      PxIcon,
+      PxText
+    },
+    template: `
+    <px-card v-bind="args" style="width: 80%">
+		  <template #prepend>
+			  <px-icon icon="check-solid" size="20" color="#ff6f5c" />
+		  </template>
+		  <template #header>
+			  <strong>Card header</strong>
+		  </template>
+		  <px-text color="#4d6bfe" size="14">
+			  This is the card body.
+		  </px-text>
+		  <template #footer>
+			  <px-text size="16">
+				  Card footer
+			  </px-text>
+		  </template>
+		  <template #append>
+			  <px-button type="success">Click me</px-button>
+		  </template>
+	  </px-card>`
+  })
 }
 
-export const Stamp: StoryFn = (args, { argTypes }) => ({
-  setup: () => ({ args }),
-  props: Object.keys(argTypes),
-  components: {
-    PxCard
+export const Stamp: Story = {
+  args: {
+    stamp: true
   },
-  template: `<div style="display:flex;justify-content:center;align-items:center;background-color:#ebe6e0;padding:20px">
+  render: (args, { argTypes }) => ({
+    setup: () => ({ args }),
+    props: Object.keys(argTypes),
+    components: {
+      PxCard
+    },
+    template: `<div style="display:flex;justify-content:center;align-items:center;background-color:#ebe6e0;padding:20px">
     <px-card v-bind="args" style="width: 80%">This is a card.</px-card>
   </div>`
-})
-
-Stamp.args = {
-  stamp: true
+  })
 }

--- a/packages/docs/storybook/stories/Collapse/Collapse.stories.ts
+++ b/packages/docs/storybook/stories/Collapse/Collapse.stories.ts
@@ -1,6 +1,10 @@
-import type { Meta, StoryFn } from '@storybook/vue3'
+import type { ArgTypes, Meta, StoryObj } from '@storybook/vue3'
 
-import { PxCollapse, PxCollapseItem } from '@pixel-ui/components'
+import {
+  PxCollapse,
+  PxCollapseItem,
+  type CollapseProps
+} from '@pixel-ui/components'
 import { PxIcon } from '@mmt817/pixel-ui'
 import '@mmt817/pixel-ui/dist/theme/Collapse.css'
 
@@ -28,8 +32,9 @@ const meta: Meta<typeof PxCollapse> = {
 }
 
 export default meta
+type Story = StoryObj<typeof meta>
 
-const Template: StoryFn = (args, { argTypes }) => ({
+const Template = (args: CollapseProps, { argTypes }: ArgTypes) => ({
   setup: () => ({ args }),
   props: Object.keys(argTypes),
   components: {
@@ -54,27 +59,32 @@ const Template: StoryFn = (args, { argTypes }) => ({
     </px-collapse>`
 })
 
-export const Default = Template.bind({})
-Default.args = {
-  modelValue: ['a'],
-  accordion: false
-}
-
-export const Accordion = Template.bind({})
-Accordion.args = {
-  modelValue: [],
-  accordion: true
-}
-
-export const CustomIcon: StoryFn = (args, { argTypes }) => ({
-  setup: () => ({ args }),
-  props: Object.keys(argTypes),
-  components: {
-    PxCollapse,
-    PxCollapseItem,
-    PxIcon
+export const Default: Story = {
+  args: {
+    modelValue: ['a'],
+    accordion: false
   },
-  template: `
+  render: Template
+}
+
+export const Accordion: Story = {
+  args: {
+    modelValue: [],
+    accordion: true
+  },
+  render: Template
+}
+
+export const CustomIcon: Story = {
+  render: (args, { argTypes }) => ({
+    setup: () => ({ args }),
+    props: Object.keys(argTypes),
+    components: {
+      PxCollapse,
+      PxCollapseItem,
+      PxIcon
+    },
+    template: `
     <px-collapse style="width: 30%" v-bind="args">
       <px-collapse-item title="Title a" name="a" icon="cog">
         <div>折叠面板内容1🐱</div>
@@ -89,4 +99,5 @@ export const CustomIcon: StoryFn = (args, { argTypes }) => ({
         <div>折叠面板内容4🐱</div>
       </px-collapse-item>
     </px-collapse>`
-})
+  })
+}

--- a/packages/docs/storybook/stories/Dropdown/Dropdown.stories.ts
+++ b/packages/docs/storybook/stories/Dropdown/Dropdown.stories.ts
@@ -1,10 +1,12 @@
-import type { Meta, StoryFn } from '@storybook/vue3'
+import type { ArgTypes, Meta, StoryObj } from '@storybook/vue3'
+import PlacementDemo from './PlacementDemo.vue'
 
 import {
   PxButton,
   PxDropdown,
   PxDropdownItem,
-  PxIcon
+  PxIcon,
+  type DropdownProps
 } from '@pixel-ui/components'
 import { ref } from 'vue'
 import '@mmt817/pixel-ui/dist/theme/Dropdown.css'
@@ -111,8 +113,9 @@ const meta: Meta<typeof PxDropdown> = {
 }
 
 export default meta
+type Story = StoryObj<typeof meta>
 
-const Template: StoryFn = (args, { argTypes }) => ({
+const Template = (args: DropdownProps, { argTypes }: ArgTypes) => ({
   setup: () => ({ args }),
   props: Object.keys(argTypes),
   components: {
@@ -130,7 +133,7 @@ const Template: StoryFn = (args, { argTypes }) => ({
   `
 })
 
-const TemplateBtn: StoryFn = (args, { argTypes }) => ({
+const TemplateBtn = (args: DropdownProps, { argTypes }: ArgTypes) => ({
   setup: () => ({ args }),
   props: Object.keys(argTypes),
   components: {
@@ -148,245 +151,149 @@ const TemplateBtn: StoryFn = (args, { argTypes }) => ({
   `
 })
 
-export const Default = TemplateBtn.bind({})
-Default.args = {
-  items: [
-    {
-      label: 'Item 1',
-      command: 'item1'
-    },
-    {
-      label: 'Item 2',
-      command: 'item2'
-    },
-    {
-      label: 'Item 3',
-      command: 'item3'
-    }
-  ]
-}
-
-export const Placement: StoryFn = (args, { argTypes }) => ({
-  setup: () => ({ args }),
-  props: Object.keys(argTypes),
-  components: {
-    PxDropdown,
-    PxDropdownItem,
-    PxButton
+export const Default: Story = {
+  args: {
+    items: [
+      {
+        label: 'Item 1',
+        command: 'item1'
+      },
+      {
+        label: 'Item 2',
+        command: 'item2'
+      },
+      {
+        label: 'Item 3',
+        command: 'item3'
+      }
+    ]
   },
-  template: `
-    <div class="dropdown-base-box" style="width:100%;height:400px;display:flex;justify-content:center;align-items:center;">
-      <div style="width:70%">
-        <div class="row center" style="display:flex;align-items:center;justify-content:center;margin-top:10px;">
-          <px-dropdown placement="top-start">
-            <px-button size="small">top-start</px-button>
-            <template #dropdown>
-                <px-dropdown-item>Action 1</px-dropdown-item>
-                <px-dropdown-item>Action 2</px-dropdown-item>
-                <px-dropdown-item>Action 3</px-dropdown-item>
-            </template>
-          </px-dropdown>
-
-          <px-dropdown placement="top">
-            <px-button size="small">top</px-button>
-            <template #dropdown>
-                <px-dropdown-item>Action 1</px-dropdown-item>
-                <px-dropdown-item>Action 2</px-dropdown-item>
-                <px-dropdown-item>Action 3</px-dropdown-item>
-            </template>
-          </px-dropdown>
-
-          <px-dropdown placement="top-end">
-            <px-button size="small">top-end</px-button>
-            <template #dropdown>
-                <px-dropdown-item>Action 1</px-dropdown-item>
-                <px-dropdown-item>Action 2</px-dropdown-item>
-                <px-dropdown-item>Action 3</px-dropdown-item>
-            </template>
-          </px-dropdown>
-        </div>
-
-        <div class="row" style="display:flex;align-items:center;justify-content:space-between;margin-top:10px;">
-          <px-dropdown placement="left-start">
-            <px-button size="small">left-start</px-button>
-            <template #dropdown>
-                <px-dropdown-item>Action 1</px-dropdown-item>
-                <px-dropdown-item>Action 2</px-dropdown-item>
-                <px-dropdown-item>Action 3</px-dropdown-item>
-            </template>
-          </px-dropdown>
-
-          <px-dropdown placement="right-start">
-            <px-button size="small">right-start</px-button>
-            <template #dropdown>
-                <px-dropdown-item>Action 1</px-dropdown-item>
-                <px-dropdown-item>Action 2</px-dropdown-item>
-                <px-dropdown-item>Action 3</px-dropdown-item>
-            </template>
-          </px-dropdown>
-        </div>
-
-        <div class="row" style="display:flex;align-items:center;justify-content:space-between;margin-top:10px;">
-          <px-dropdown placement="left">
-            <px-button size="small" class="mt-3 mb-3">left</px-button>
-            <template #dropdown>
-                <px-dropdown-item>Action 1</px-dropdown-item>
-                <px-dropdown-item>Action 2</px-dropdown-item>
-                <px-dropdown-item>Action 3</px-dropdown-item>
-            </template>
-          </px-dropdown>
-
-          <px-dropdown placement="right">
-            <px-button size="small">right</px-button>
-            <template #dropdown>
-                <px-dropdown-item>Action 1</px-dropdown-item>
-                <px-dropdown-item>Action 2</px-dropdown-item>
-                <px-dropdown-item>Action 3</px-dropdown-item>
-            </template>
-          </px-dropdown>
-        </div>
-
-        <div class="row" style="display:flex;align-items:center;justify-content:space-between;margin-top:10px;">
-          <px-dropdown placement="left-end">
-            <px-button size="small">left-end</px-button>
-            <template #dropdown>
-                <px-dropdown-item>Action 1</px-dropdown-item>
-                <px-dropdown-item>Action 2</px-dropdown-item>
-                <px-dropdown-item>Action 3</px-dropdown-item>
-            </template>
-          </px-dropdown>
-
-          <px-dropdown placement="right-end">
-            <px-button size="small">right-end</px-button>
-            <template #dropdown>
-                <px-dropdown-item>Action 1</px-dropdown-item>
-                <px-dropdown-item>Action 2</px-dropdown-item>
-                <px-dropdown-item>Action 3</px-dropdown-item>
-            </template>
-          </px-dropdown>
-        </div>
-
-        <div class="row center" style="display:flex;align-items:center;justify-content:center;margin-top:10px;">
-          <px-dropdown placement="bottom-start">
-            <px-button size="small">bottom-start</px-button>
-            <template #dropdown>
-                <px-dropdown-item>Action 1</px-dropdown-item>
-                <px-dropdown-item>Action 2</px-dropdown-item>
-                <px-dropdown-item>Action 3</px-dropdown-item>
-            </template>
-          </px-dropdown>
-
-          <px-dropdown placement="bottom">
-            <px-button size="small">bottom</px-button>
-            <template #dropdown>
-                <px-dropdown-item>Action 1</px-dropdown-item>
-                <px-dropdown-item>Action 2</px-dropdown-item>
-                <px-dropdown-item>Action 3</px-dropdown-item>
-            </template>
-          </px-dropdown>
-
-          <px-dropdown placement="bottom-end">
-            <px-button size="small">bottom-end</px-button>
-            <template #dropdown>
-                <px-dropdown-item>Action 1</px-dropdown-item>
-                <px-dropdown-item>Action 2</px-dropdown-item>
-                <px-dropdown-item>Action 3</px-dropdown-item>
-            </template>
-          </px-dropdown>
-        </div>
-      </div>
-    </div>
-  `
-})
-
-export const SplitButton = Template.bind({})
-SplitButton.args = {
-  items: [
-    {
-      label: 'Item 1',
-      command: 'item1'
-    },
-    {
-      label: 'Item 2',
-      command: 'item2'
-    },
-    {
-      label: 'Item 3',
-      command: 'item3'
-    }
-  ],
-  splitButton: true
+  render: TemplateBtn
 }
-
-export const Trigger = TemplateBtn.bind({})
-Trigger.args = {
-  items: [
-    {
-      label: 'Item 1',
-      command: 'item1'
-    },
-    {
-      label: 'Item 2',
-      command: 'item2'
-    },
-    {
-      label: 'Item 3',
-      command: 'item3'
-    }
-  ],
-  trigger: 'click'
-}
-
-export const Disabled = Template.bind({})
-Disabled.args = {
-  items: [
-    {
-      label: 'Item 1',
-      command: 'item1'
-    },
-    {
-      label: 'Item 2',
-      command: 'item2'
-    },
-    {
-      label: 'Item 3',
-      command: 'item3'
-    }
-  ],
-  disabled: true
-}
-
-export const HideOnClick = TemplateBtn.bind({})
-HideOnClick.args = {
-  items: [
-    {
-      label: 'Item 1',
-      command: 'item1'
-    },
-    {
-      label: 'Item 2',
-      command: 'item2'
-    },
-    {
-      label: 'Item 3',
-      command: 'item3'
-    }
-  ],
-  hideOnClick: false
-}
-
-export const Manual: StoryFn = (args, { argTypes }) => ({
-  setup() {
-    const dropdownRef = ref()
-    return { args, dropdownRef }
+export const HideOnClick: Story = {
+  args: {
+    items: [
+      {
+        label: 'Item 1',
+        command: 'item1'
+      },
+      {
+        label: 'Item 2',
+        command: 'item2'
+      },
+      {
+        label: 'Item 3',
+        command: 'item3'
+      }
+    ],
+    hideOnClick: false
   },
-  props: Object.keys(argTypes),
-  components: {
-    PxDropdown,
-    PxDropdownItem,
-    PxButton
+  render: TemplateBtn
+}
+
+export const Trigger: Story = {
+  args: {
+    items: [
+      {
+        label: 'Item 1',
+        command: 'item1'
+      },
+      {
+        label: 'Item 2',
+        command: 'item2'
+      },
+      {
+        label: 'Item 3',
+        command: 'item3'
+      }
+    ],
+    trigger: 'click'
   },
-  template: `
+  render: TemplateBtn
+}
+export const SplitButton: Story = {
+  args: {
+    items: [
+      {
+        label: 'Item 1',
+        command: 'item1'
+      },
+      {
+        label: 'Item 2',
+        command: 'item2'
+      },
+      {
+        label: 'Item 3',
+        command: 'item3'
+      }
+    ],
+    splitButton: true
+  },
+  render: Template
+}
+
+// export const Disabled = Template.bind({})
+export const Disabled: Story = {
+  args: {
+    items: [
+      {
+        label: 'Item 1',
+        command: 'item1'
+      },
+      {
+        label: 'Item 2',
+        command: 'item2'
+      },
+      {
+        label: 'Item 3',
+        command: 'item3'
+      }
+    ],
+    disabled: true
+  },
+  render: Template
+}
+
+export const Placement: Story = {
+  render: (args, { argTypes }) => ({
+    setup: () => ({ args }),
+    props: Object.keys(argTypes),
+    components: {
+      PlacementDemo
+    },
+    template: `<PlacementDemo v-bind='args' />`
+  })
+}
+export const Manual: Story = {
+  args: {
+    items: [
+      {
+        label: '选项一',
+        command: '1'
+      },
+      {
+        label: '选项二',
+        command: '2'
+      },
+      {
+        label: '选项三',
+        command: '3'
+      }
+    ],
+    trigger: 'click'
+  },
+  render: (args, { argTypes }) => ({
+    setup() {
+      const dropdownRef = ref()
+      return { args, dropdownRef }
+    },
+    props: Object.keys(argTypes),
+    components: {
+      PxDropdown,
+      PxDropdownItem,
+      PxButton
+    },
+    template: `
     <div>
       <px-button @click="() => dropdownRef?.open()" size="small">open</px-button>
       <px-button @click="() => dropdownRef?.close()" size="small">close</px-button>
@@ -397,35 +304,20 @@ export const Manual: StoryFn = (args, { argTypes }) => ({
       </px-dropdown>
     </div>
   `
-})
-Manual.args = {
-  items: [
-    {
-      label: '选项一',
-      command: '1'
-    },
-    {
-      label: '选项二',
-      command: '2'
-    },
-    {
-      label: '选项三',
-      command: '3'
-    }
-  ],
-  trigger: 'click'
+  })
 }
 
-export const Size: StoryFn = (args, { argTypes }) => ({
-  setup: () => ({ args }),
-  props: Object.keys(argTypes),
-  components: {
-    PxDropdown,
-    PxDropdownItem,
-    PxIcon,
-    PxButton
-  },
-  template: `
+export const Size: Story = {
+  render: (args, { argTypes }) => ({
+    setup: () => ({ args }),
+    props: Object.keys(argTypes),
+    components: {
+      PxDropdown,
+      PxDropdownItem,
+      PxIcon,
+      PxButton
+    },
+    template: `
     <div class="px-dropdown-container" style="width: 100%; height: 200px; display: flex; justify-content: center;">
       <px-dropdown size="large" split-button type="primary">
         Large
@@ -458,4 +350,5 @@ export const Size: StoryFn = (args, { argTypes }) => ({
       </px-dropdown>
     </div>
   `
-})
+  })
+}

--- a/packages/docs/storybook/stories/Dropdown/PlacementDemo.vue
+++ b/packages/docs/storybook/stories/Dropdown/PlacementDemo.vue
@@ -1,0 +1,146 @@
+<script setup lang="ts">
+import { PxDropdown, PxDropdownItem, PxButton } from '@pixel-ui/components'
+</script>
+
+<template>
+  <div class="dropdown-base-box">
+    <div class="row center">
+      <px-dropdown placement="top-start">
+        <px-button>top-start</px-button>
+        <template #dropdown>
+          <px-dropdown-item>Action 1</px-dropdown-item>
+          <px-dropdown-item>Action 2</px-dropdown-item>
+          <px-dropdown-item>Action 3</px-dropdown-item>
+        </template>
+      </px-dropdown>
+
+      <px-dropdown placement="top">
+        <px-button>top</px-button>
+        <template #dropdown>
+          <px-dropdown-item>Action 1</px-dropdown-item>
+          <px-dropdown-item>Action 2</px-dropdown-item>
+          <px-dropdown-item>Action 3</px-dropdown-item>
+        </template>
+      </px-dropdown>
+
+      <px-dropdown placement="top-end">
+        <px-button>top-end</px-button>
+        <template #dropdown>
+          <px-dropdown-item>Action 1</px-dropdown-item>
+          <px-dropdown-item>Action 2</px-dropdown-item>
+          <px-dropdown-item>Action 3</px-dropdown-item>
+        </template>
+      </px-dropdown>
+    </div>
+
+    <div class="row">
+      <px-dropdown placement="left-start">
+        <px-button>left-start</px-button>
+        <template #dropdown>
+          <px-dropdown-item>Action 1</px-dropdown-item>
+          <px-dropdown-item>Action 2</px-dropdown-item>
+          <px-dropdown-item>Action 3</px-dropdown-item>
+        </template>
+      </px-dropdown>
+
+      <px-dropdown placement="right-start">
+        <px-button>right-start</px-button>
+        <template #dropdown>
+          <px-dropdown-item>Action 1</px-dropdown-item>
+          <px-dropdown-item>Action 2</px-dropdown-item>
+          <px-dropdown-item>Action 3</px-dropdown-item>
+        </template>
+      </px-dropdown>
+    </div>
+
+    <div class="row">
+      <px-dropdown placement="left">
+        <px-button class="mt-3 mb-3">left</px-button>
+        <template #dropdown>
+          <px-dropdown-item>Action 1</px-dropdown-item>
+          <px-dropdown-item>Action 2</px-dropdown-item>
+          <px-dropdown-item>Action 3</px-dropdown-item>
+        </template>
+      </px-dropdown>
+
+      <px-dropdown placement="right">
+        <px-button>right</px-button>
+        <template #dropdown>
+          <px-dropdown-item>Action 1</px-dropdown-item>
+          <px-dropdown-item>Action 2</px-dropdown-item>
+          <px-dropdown-item>Action 3</px-dropdown-item>
+        </template>
+      </px-dropdown>
+    </div>
+
+    <div class="row">
+      <px-dropdown placement="left-end">
+        <px-button>left-end</px-button>
+        <template #dropdown>
+          <px-dropdown-item>Action 1</px-dropdown-item>
+          <px-dropdown-item>Action 2</px-dropdown-item>
+          <px-dropdown-item>Action 3</px-dropdown-item>
+        </template>
+      </px-dropdown>
+
+      <px-dropdown placement="right-end">
+        <px-button>right-end</px-button>
+        <template #dropdown>
+          <px-dropdown-item>Action 1</px-dropdown-item>
+          <px-dropdown-item>Action 2</px-dropdown-item>
+          <px-dropdown-item>Action 3</px-dropdown-item>
+        </template>
+      </px-dropdown>
+    </div>
+
+    <div class="row center">
+      <px-dropdown placement="bottom-start">
+        <px-button>bottom-start</px-button>
+        <template #dropdown>
+          <px-dropdown-item>Action 1</px-dropdown-item>
+          <px-dropdown-item>Action 2</px-dropdown-item>
+          <px-dropdown-item>Action 3</px-dropdown-item>
+        </template>
+      </px-dropdown>
+
+      <px-dropdown placement="bottom">
+        <px-button>bottom</px-button>
+        <template #dropdown>
+          <px-dropdown-item>Action 1</px-dropdown-item>
+          <px-dropdown-item>Action 2</px-dropdown-item>
+          <px-dropdown-item>Action 3</px-dropdown-item>
+        </template>
+      </px-dropdown>
+
+      <px-dropdown placement="bottom-end">
+        <px-button>bottom-end</px-button>
+        <template #dropdown>
+          <px-dropdown-item>Action 1</px-dropdown-item>
+          <px-dropdown-item>Action 2</px-dropdown-item>
+          <px-dropdown-item>Action 3</px-dropdown-item>
+        </template>
+      </px-dropdown>
+    </div>
+  </div>
+</template>
+
+<style>
+.dropdown-base-box .row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.dropdown-base-box .center {
+  justify-content: center;
+}
+
+.dropdown-base-box .row .px-dropdown {
+  margin-top: 10px;
+}
+
+.dropdown-base-box {
+  width: 70%;
+  margin: 120px auto 0;
+}
+</style>

--- a/packages/docs/storybook/stories/Icon/Icon.stories.ts
+++ b/packages/docs/storybook/stories/Icon/Icon.stories.ts
@@ -1,4 +1,4 @@
-import type { Meta, StoryFn } from '@storybook/vue3'
+import type { Meta, StoryObj } from '@storybook/vue3'
 
 // import { PxIcon } from '@mmt817/pixel-ui'
 import { PxIcon } from '@pixel-ui/components'
@@ -61,63 +61,72 @@ const meta: Meta<typeof PxIcon> = {
 
 export default meta
 
-const Template: StoryFn = (args, { argTypes }) => ({
-  setup: () => ({ args }),
-  props: Object.keys(argTypes),
-  components: {
-    PxIcon
-  },
-  template: `<px-icon v-bind="args" />`
-})
+type Story = StoryObj<typeof meta>
 
 // 默认示例
-export const Default = Template.bind({})
-Default.args = {
-  icon: 'face-thinking-solid',
-  size: 38
+export const Default: Story = {
+  args: {
+    icon: 'face-thinking-solid',
+    size: 38
+  },
+  render: (args, { argTypes }) => ({
+    setup: () => ({ args }),
+    props: Object.keys(argTypes),
+    components: {
+      PxIcon
+    },
+    template: `<px-icon v-bind="args" />`
+  })
 }
 
 // 颜色示例
-export const Colors: StoryFn = (args, { argTypes }) => ({
-  setup: () => ({ args }),
-  props: Object.keys(argTypes),
-  components: {
-    PxIcon
-  },
-  template: `
+export const Colors: Story = {
+  args: {},
+  render: (args, { argTypes }) => ({
+    setup: () => ({ args }),
+    props: Object.keys(argTypes),
+    components: {
+      PxIcon
+    },
+    template: `
     <px-icon v-bind="args" color="#ff4785" icon="face-thinking-solid" size="38" />
     <px-icon v-bind="args" color="rgb(0,212,255)"icon="face-thinking-solid" size="38" />
     <px-icon v-bind="args" color="hsl(265, 100%, 50%)" icon="face-thinking-solid" size="38" />
     <px-icon v-bind="args" color="hwb(38 0% 0%)" icon="face-thinking-solid" size="38" />
   `
-})
+  })
+}
 
 // 动画示例
-export const Animations: StoryFn = (args, { argTypes }) => ({
-  setup: () => ({ args }),
-  props: Object.keys(argTypes),
-  components: {
-    PxIcon
-  },
-  template: `
+export const Animations: Story = {
+  render: (args, { argTypes }) => ({
+    setup: () => ({ args }),
+    props: Object.keys(argTypes),
+    components: {
+      PxIcon
+    },
+    template: `
     <px-icon v-bind="args" spin type="primary" icon="face-thinking-solid" size="38" />
     <px-icon v-bind="args" bounce type="success" icon="face-thinking-solid" size="38" />
     <px-icon v-bind="args" shake type="warning" icon="face-thinking-solid" size="38" />
     <px-icon v-bind="args" beat type="danger" icon="face-thinking-solid" size="38" />
   `
-})
+  })
+}
 
 // 翻转和旋转示例
-export const Transformations: StoryFn = (args, { argTypes }) => ({
-  setup: () => ({ args }),
-  props: Object.keys(argTypes),
-  components: {
-    PxIcon
-  },
-  template: `
+export const Transformations: Story = {
+  render: (args, { argTypes }) => ({
+    setup: () => ({ args }),
+    props: Object.keys(argTypes),
+    components: {
+      PxIcon
+    },
+    template: `
     <px-icon v-bind="args" flip="horizontal" type="primary" icon="face-thinking-solid" size="38" />
     <px-icon v-bind="args" flip="vertical" type="success" icon="face-thinking-solid" size="38" />
     <px-icon v-bind="args" flip="both" type="warning" icon="face-thinking-solid" size="38" />
     <px-icon v-bind="args" rotation="270" type="danger" icon="face-thinking-solid" size="38" />
   `
-})
+  })
+}

--- a/packages/docs/storybook/stories/Image/Image.stories.ts
+++ b/packages/docs/storybook/stories/Image/Image.stories.ts
@@ -1,7 +1,8 @@
-import type { Meta, StoryFn } from '@storybook/vue3'
+import type { ArgTypes, Meta, StoryObj } from '@storybook/vue3'
 
 import { PxImage } from '@pixel-ui/components'
 import '@mmt817/pixel-ui/dist/theme/Image.css'
+import type { ImageProps } from '@mmt817/pixel-ui'
 
 const meta: Meta<typeof PxImage> = {
   title: 'Fantastic/Image',
@@ -43,7 +44,9 @@ const Starbucks = '../assets/images/Starbucks.png'
 const xtaffy = '../assets/images/xtaffy.png'
 const xinlang = '../assets/images/xinlang.jpg'
 
-const Template: StoryFn = (args, { argTypes }) => ({
+type Story = StoryObj<typeof meta>
+
+const Template = (args: ImageProps, { argTypes }: ArgTypes) => ({
   setup: () => ({ args }),
   props: Object.keys(argTypes),
   components: { PxImage },
@@ -56,25 +59,31 @@ const Template: StoryFn = (args, { argTypes }) => ({
   `
 })
 
-export const Default = Template.bind({})
-Default.args = {
-  src: Starbucks,
-  width: 395,
-  height: 400,
-  blockSize: 5,
-  colorCount: 18
+export const Default: Story = {
+  args: {
+    src: Starbucks,
+    width: 395,
+    height: 400,
+    blockSize: 5,
+    colorCount: 18
+  },
+  render: Template
 }
-export const Custom = Template.bind({})
-Custom.args = {
-  src: xtaffy,
-  blockSize: 5,
-  colorCount: 35,
-  scale: 0.8
+export const Customo: Story = {
+  args: {
+    src: xtaffy,
+    blockSize: 5,
+    colorCount: 35,
+    scale: 0.8
+  },
+  render: Template
 }
-export const withGrid = Template.bind({})
-withGrid.args = {
-  src: xinlang,
-  blockSize: 4,
-  colorCount: 18,
-  showGrid: true
+export const withGrid: Story = {
+  args: {
+    src: xinlang,
+    blockSize: 4,
+    colorCount: 18,
+    showGrid: true
+  },
+  render: Template
 }

--- a/packages/docs/storybook/stories/Input/Input.stories.ts
+++ b/packages/docs/storybook/stories/Input/Input.stories.ts
@@ -1,4 +1,4 @@
-import type { Meta, StoryFn } from '@storybook/vue3'
+import type { Meta, StoryObj } from '@storybook/vue3'
 
 import InputDemo from './InputDemo.vue'
 import { PxIcon, PxInput, type InputProps } from '@pixel-ui/components'
@@ -69,7 +69,9 @@ const meta: Meta<typeof PxInput> = {
 
 export default meta
 
-const Template: StoryFn<typeof PxInput> = (args: InputProps) => ({
+type Story = StoryObj<typeof meta>
+
+const Template = (args: InputProps) => ({
   components: { PxInput },
   setup() {
     return { args }
@@ -79,33 +81,50 @@ const Template: StoryFn<typeof PxInput> = (args: InputProps) => ({
   `
 })
 
-export const Default = Template.bind({})
-Default.args = {}
-
-export const Disabled = Template.bind({})
-Disabled.args = {
-  disabled: true
+export const Default: Story = {
+  args: {},
+  render: Template
 }
 
-export const Clearable = Template.bind({})
-Clearable.args = {
-  modelValue: '待清空内容',
-  clearable: true
-}
-
-export const Password = Template.bind({})
-Password.args = {
-  modelValue: '123456',
-  type: 'password',
-  showPassword: true
-}
-
-export const WithIcon: StoryFn<typeof PxInput> = (args: InputProps) => ({
-  components: { PxInput, PxIcon },
-  setup() {
-    return { args }
+export const Disabled: Story = {
+  args: {
+    disabled: true
   },
-  template: `
+  render: Template
+}
+
+export const Clearable: Story = {
+  args: {
+    modelValue: '待清空内容',
+    clearable: true
+  },
+  render: Template
+}
+
+export const Password: Story = {
+  args: {
+    modelValue: '123456',
+    type: 'password',
+    showPassword: true
+  },
+  render: Template
+}
+
+export const Textarea: Story = {
+  args: {
+    type: 'textarea'
+  },
+  render: Template
+}
+
+export const WithIcon: Story = {
+  args: {},
+  render: (args: InputProps) => ({
+    components: { PxInput, PxIcon },
+    setup() {
+      return { args }
+    },
+    template: `
     <px-input v-bind="args" style="width: 340px; margin-right: 10px;" placeholder="Pick a date">
       <template #suffix>
         <px-icon icon="calender-solid" />
@@ -121,24 +140,23 @@ export const WithIcon: StoryFn<typeof PxInput> = (args: InputProps) => ({
       </template>
     </px-input>
   `
-})
-
-export const Textarea = Template.bind({})
-Textarea.args = {
-  type: 'textarea'
+  })
 }
 
-export const WithSlots: StoryFn = () => ({
-  components: { InputDemo },
-  template: `<InputDemo />`
-})
+export const WithSlots: Story = {
+  render: () => ({
+    components: { InputDemo },
+    template: `<InputDemo />`
+  })
+}
 
-export const Size: StoryFn<typeof PxInput> = (args: InputProps) => ({
-  components: { PxInput },
-  setup() {
-    return { args }
-  },
-  template: `
+export const Size: Story = {
+  render: (args: InputProps) => ({
+    components: { PxInput },
+    setup() {
+      return { args }
+    },
+    template: `
     <div style="margin-bottom: 8px;">
       <px-input v-bind="args" size="large" style="width: 340px" />
     </div>
@@ -149,4 +167,5 @@ export const Size: StoryFn<typeof PxInput> = (args: InputProps) => ({
       <px-input v-bind="args" size="small" style="width: 340px" />
     </div>
   `
-})
+  })
+}

--- a/packages/docs/storybook/stories/Message/Message.stories.ts
+++ b/packages/docs/storybook/stories/Message/Message.stories.ts
@@ -1,4 +1,4 @@
-import type { Meta, StoryFn } from '@storybook/vue3'
+import type { Meta, StoryObj } from '@storybook/vue3'
 import MessageDemo from './MessageDemo.vue'
 import '@mmt817/pixel-ui/dist/theme/Button.css'
 import '@mmt817/pixel-ui/dist/theme/Message.css'
@@ -54,10 +54,14 @@ const meta: Meta<typeof MessageDemo> = {
 
 export default meta
 
-export const Default: StoryFn = (args) => ({
-  components: { MessageDemo },
-  setup() {
-    return { args }
-  },
-  template: '<MessageDemo v-bind="args" />'
-})
+type Story = StoryObj<typeof meta>
+
+export const Default: Story = {
+  render: (args) => ({
+    components: { MessageDemo },
+    setup() {
+      return { args }
+    },
+    template: '<MessageDemo v-bind="args" />'
+  })
+}

--- a/packages/docs/storybook/stories/Notification/Notification.stories.ts
+++ b/packages/docs/storybook/stories/Notification/Notification.stories.ts
@@ -1,4 +1,4 @@
-import type { Meta, StoryFn } from '@storybook/vue3'
+import type { Meta, StoryObj } from '@storybook/vue3'
 import NotificationDemo from './NotificationDemo.vue'
 import '@mmt817/pixel-ui/dist/theme/Button.css'
 import '@mmt817/pixel-ui/dist/theme/Notification.css'
@@ -59,10 +59,14 @@ const meta: Meta<typeof NotificationDemo> = {
 
 export default meta
 
-export const Default: StoryFn = (args) => ({
-  components: { NotificationDemo },
-  setup() {
-    return { args }
-  },
-  template: '<NotificationDemo v-bind="args" />'
-})
+type Story = StoryObj<typeof meta>
+
+export const Default: Story = {
+  render: (args) => ({
+    components: { NotificationDemo },
+    setup() {
+      return { args }
+    },
+    template: '<NotificationDemo v-bind="args" />'
+  })
+}

--- a/packages/docs/storybook/stories/Pixelit/Pixelit.stories.ts
+++ b/packages/docs/storybook/stories/Pixelit/Pixelit.stories.ts
@@ -1,6 +1,6 @@
-import type { Meta, StoryFn } from '@storybook/vue3'
+import type { ArgTypes, Meta, StoryObj } from '@storybook/vue3'
 
-import { PxPixelIt } from '@pixel-ui/components'
+import { PxPixelIt, type PixelItProps } from '@pixel-ui/components'
 import '@mmt817/pixel-ui/dist/theme/PixelIt.css'
 
 const meta: Meta<typeof PxPixelIt> = {
@@ -39,12 +39,14 @@ const meta: Meta<typeof PxPixelIt> = {
 
 export default meta
 
+type Story = StoryObj<typeof meta>
+
 const Starbucks = '../assets/images/Starbucks.png'
 const xtaffy = '../assets/images/xtaffy.png'
 const monaka = '../assets/images/monaka.jpg'
 const human = '../assets/images/e.png'
 
-const Template: StoryFn = (args, { argTypes }) => ({
+const Template = (args: PixelItProps, { argTypes }: ArgTypes) => ({
   setup: () => ({ args }),
   props: Object.keys(argTypes),
   components: { PxPixelIt },
@@ -57,36 +59,44 @@ const Template: StoryFn = (args, { argTypes }) => ({
   `
 })
 
-export const Default = Template.bind({})
-Default.args = {
-  src: human,
-  scale: 4
+export const Default: Story = {
+  args: {
+    src: human,
+    scale: 4
+  },
+  render: Template
 }
-export const Size = Template.bind({})
-Size.args = {
-  src: monaka,
-  scale: 5,
-  aspectRatio: 0.5
+export const Size: Story = {
+  args: {
+    src: monaka,
+    scale: 5,
+    aspectRatio: 0.5
+  },
+  render: Template
 }
-export const Gray = Template.bind({})
-Gray.args = {
-  src: xtaffy,
-  scale: 4,
-  grayscale: true
+export const Gray: Story = {
+  args: {
+    src: xtaffy,
+    scale: 4,
+    grayscale: true
+  },
+  render: Template
 }
-export const Palette = Template.bind({})
-Palette.args = {
-  src: Starbucks,
-  scale: 4,
-  aspectRatio: 0.5,
-  palette: [
-    [0, 0, 0],
-    [29, 43, 83],
-    [126, 37, 83],
-    [0, 135, 81],
-    [171, 82, 54],
-    [95, 87, 79],
-    [194, 195, 199],
-    [255, 241, 232]
-  ]
+export const Palette: Story = {
+  args: {
+    src: Starbucks,
+    scale: 4,
+    aspectRatio: 0.5,
+    palette: [
+      [0, 0, 0],
+      [29, 43, 83],
+      [126, 37, 83],
+      [0, 135, 81],
+      [171, 82, 54],
+      [95, 87, 79],
+      [194, 195, 199],
+      [255, 241, 232]
+    ]
+  },
+  render: Template
 }

--- a/packages/docs/storybook/stories/Popconfirm/Popconfirm.stories.ts
+++ b/packages/docs/storybook/stories/Popconfirm/Popconfirm.stories.ts
@@ -1,7 +1,7 @@
-import type { Meta, StoryFn } from '@storybook/vue3'
+import type { Meta, StoryObj } from '@storybook/vue3'
 import { fn } from '@storybook/test'
 
-import { PxPopconfirm } from '@pixel-ui/components'
+import { PxPopconfirm, type PopconfirmProps } from '@pixel-ui/components'
 import { PxButton } from '@mmt817/pixel-ui'
 
 import '@mmt817/pixel-ui/dist/theme/Popconfirm.css'
@@ -73,7 +73,9 @@ const meta: Meta<typeof PxPopconfirm> = {
 
 export default meta
 
-const Template: StoryFn = (args) => ({
+type Story = StoryObj<typeof meta>
+
+const Template = (args: PopconfirmProps) => ({
   components: { PxPopconfirm, PxButton },
   setup() {
     return { args }
@@ -87,40 +89,51 @@ const Template: StoryFn = (args) => ({
   `
 })
 
-export const Default = Template.bind({})
-Default.args = {
-  title: '你确定要执行此操作吗？'
+export const Default: Story = {
+  args: {
+    title: '你确定要执行此操作吗? '
+  },
+  render: Template
 }
 
-export const HideIcon = Template.bind({})
-HideIcon.args = {
-  title: '没有图标的提示',
-  hideIcon: true
+export const HideIcon: Story = {
+  args: {
+    title: '没有图标的提示',
+    hideIcon: true
+  },
+  render: Template
+}
+export const CustomIcon: Story = {
+  args: {
+    title: '自定义图标和颜色',
+    icon: 'info-circle-solid',
+    iconColor: '#626AEF'
+  },
+  render: Template
 }
 
-export const CustomIcon = Template.bind({})
-CustomIcon.args = {
-  title: '自定义图标和颜色',
-  icon: 'info-circle-solid',
-  iconColor: '#626AEF'
+export const CustomWidth: Story = {
+  args: {
+    title: '更宽的 Popconfirm 弹层',
+    width: 300
+  },
+  render: Template
 }
 
-export const CustomWidth = Template.bind({})
-CustomWidth.args = {
-  title: '更宽的 Popconfirm 弹层',
-  width: 300
+export const CustomType: Story = {
+  args: {
+    title: '成功类型按钮',
+    confirmButtonType: 'success',
+    cancelButtonType: 'warning'
+  },
+  render: Template
 }
 
-export const CustomType = Template.bind({})
-CustomType.args = {
-  title: '成功类型按钮',
-  confirmButtonType: 'success',
-  cancelButtonType: 'warning'
-}
-
-export const CustomText = Template.bind({})
-CustomText.args = {
-  title: '自定义按钮文字',
-  confirmButtonText: '确定',
-  cancelButtonText: '取消'
+export const CustomText: Story = {
+  args: {
+    title: '自定义按钮文字',
+    confirmButtonText: '确定',
+    cancelButtonText: '取消'
+  },
+  render: Template
 }

--- a/packages/docs/storybook/stories/Progress/Progress.stories.ts
+++ b/packages/docs/storybook/stories/Progress/Progress.stories.ts
@@ -1,7 +1,7 @@
-import type { Meta, StoryFn } from '@storybook/vue3'
+import type { Meta, StoryObj } from '@storybook/vue3'
 
-// import { PxProgress } from '@mmt817/pixel-ui'
-import { PxProgress } from '@pixel-ui/components'
+// import { PxProgress, type ProgressProps } from '@mmt817/pixel-ui'
+import { PxProgress, type ProgressProps } from '@pixel-ui/components'
 import '@mmt817/pixel-ui/dist/theme/Progress.css'
 
 const meta: Meta<typeof PxProgress> = {
@@ -61,7 +61,9 @@ const meta: Meta<typeof PxProgress> = {
 
 export default meta
 
-const Template: StoryFn = (args) => ({
+type Story = StoryObj<typeof meta>
+
+const Template = (args: ProgressProps) => ({
   components: { PxProgress },
   setup() {
     return { args }
@@ -75,67 +77,83 @@ const Template: StoryFn = (args) => ({
   `
 })
 
-export const Default = Template.bind({})
-Default.args = {
-  percentage: 50
-}
-
-export const StrokeWidth = Template.bind({})
-StrokeWidth.args = {
-  percentage: 75,
-  strokeWidth: 30
-}
-
-export const TextInside = Template.bind({})
-TextInside.args = {
-  percentage: 75,
-  strokeWidth: 24,
-  textInside: true
-}
-
-export const Indeterminate = Template.bind({})
-Indeterminate.args = {
-  percentage: 75,
-  indeterminate: true,
-  duration: 4
-}
-
-export const CustomColor: StoryFn = (args) => ({
-  components: { PxProgress },
-  setup() {
-    return { args }
+export const Default: Story = {
+  args: {
+    percentage: 50
   },
-  template: `
+  render: Template
+}
+
+export const StrokeWidth: Story = {
+  args: {
+    percentage: 75,
+    strokeWidth: 30
+  },
+  render: Template
+}
+
+export const TextInside: Story = {
+  args: {
+    percentage: 75,
+    strokeWidth: 24,
+    textInside: true
+  },
+  render: Template
+}
+
+export const Indeterminate: Story = {
+  args: {
+    percentage: 75,
+    indeterminate: true,
+    duration: 4
+  },
+  render: Template
+}
+
+export const Striped: Story = {
+  args: {
+    percentage: 75,
+    strokeWidth: 24,
+    striped: true
+  },
+  render: Template
+}
+
+export const StripedFlow: Story = {
+  args: {
+    percentage: 75,
+    strokeWidth: 24,
+    striped: true,
+    stripedFlow: true
+  },
+  render: Template
+}
+
+export const Checker: Story = {
+  args: {
+    percentage: 75,
+    strokeWidth: 24,
+    checker: true
+  },
+  render: Template
+}
+
+export const CustomColor: Story = {
+  args: {
+    percentage: 75,
+    strokeWidth: 24,
+    striped: true
+  },
+  render: (args) => ({
+    components: { PxProgress },
+    setup() {
+      return { args }
+    },
+    template: `
     <PxProgress v-bind="args" color="#626aef" style="marginBottom:25px" />
     <PxProgress v-bind="args" color="#ff4785" style="marginBottom:25px" />
     <PxProgress v-bind="args" color="#08979c" style="marginBottom:25px" />
     <PxProgress v-bind="args" color="#ad4e00" style="marginBottom:25px" />
   `
-})
-CustomColor.args = {
-  percentage: 75,
-  strokeWidth: 24,
-  striped: true
-}
-
-export const Striped = Template.bind({})
-Striped.args = {
-  percentage: 75,
-  strokeWidth: 24,
-  striped: true
-}
-
-export const StripedFlow = Template.bind({})
-StripedFlow.args = {
-  percentage: 75,
-  strokeWidth: 24,
-  striped: true,
-  stripedFlow: true
-}
-
-export const Checker = Template.bind({})
-Checker.args = {
-  percentage: 75,
-  strokeWidth: 24,
-  checker: true
+  })
 }

--- a/packages/docs/storybook/stories/Tag/Tag.stories.ts
+++ b/packages/docs/storybook/stories/Tag/Tag.stories.ts
@@ -1,6 +1,6 @@
-import type { Meta, StoryFn } from '@storybook/vue3'
+import type { Meta, StoryObj } from '@storybook/vue3'
 
-import { PxTag, PxIcon } from '@pixel-ui/components'
+import { PxTag, PxIcon, type TagProps } from '@pixel-ui/components'
 import '@mmt817/pixel-ui/dist/theme/Tag.css'
 import '@mmt817/pixel-ui/dist/theme/Icon.css'
 
@@ -32,25 +32,29 @@ const meta: Meta<typeof PxTag> = {
 
 export default meta
 
-const Template: StoryFn = (args) => ({
-  components: { PxTag },
-  setup() {
-    return { args }
-  },
-  template: `
+type Story = StoryObj<typeof meta>
+
+export const Default: Story = {
+  render: (args: TagProps) => ({
+    components: { PxTag },
+    setup() {
+      return { args }
+    },
+    template: `
     <div class="px-badge-container">
       <px-tag v-bind="args">Tag</px-tag>
     </div>
   `
-})
-export const Default = Template.bind({})
+  })
+}
 
-export const Types: StoryFn = (args) => ({
-  components: { PxTag, PxIcon },
-  setup() {
-    return { args }
-  },
-  template: `
+export const Types: Story = {
+  render: (args) => ({
+    components: { PxTag, PxIcon },
+    setup() {
+      return { args }
+    },
+    template: `
     <div class="px-badge-container">
       <px-tag v-bind="args" type="primary">Primary</px-tag>
       <px-tag v-bind="args" type="success">Success</px-tag>
@@ -63,13 +67,16 @@ export const Types: StoryFn = (args) => ({
       </px-tag>
     </div>
   `
-})
-export const Closable: StoryFn = (args) => ({
-  components: { PxTag },
-  setup() {
-    return { args }
-  },
-  template: `
+  })
+}
+
+export const Closable: Story = {
+  render: (args) => ({
+    components: { PxTag },
+    setup() {
+      return { args }
+    },
+    template: `
     <div class="px-badge-container">
       <px-tag v-bind="args" type="primary" closable @close="handleClose">Primary</px-tag>
       <px-tag v-bind="args" type="success" closable @close="handleClose">Success</px-tag>
@@ -78,82 +85,97 @@ export const Closable: StoryFn = (args) => ({
       <px-tag v-bind="args" type="sakura" closable @close="handleClose">Sakura</px-tag>
     </div>
   `
-})
-export const Sizes: StoryFn = (args) => ({
-  components: { PxTag },
-  setup() {
-    return { args }
-  },
-  template: `
+  })
+}
+
+export const Sizes: Story = {
+  render: (args) => ({
+    components: { PxTag },
+    setup() {
+      return { args }
+    },
+    template: `
     <div class="px-badge-container">
       <px-tag v-bind="args" size="large">Large</px-tag>
       <px-tag v-bind="args" size="default">Default</px-tag>
       <px-tag v-bind="args" size="small">Small</px-tag>
     </div>
     `
-})
-export const Effect: StoryFn = (args) => ({
-  components: { PxTag },
-  setup() {
-    return { args }
-  },
-  template: `
+  })
+}
+export const Effect: Story = {
+  render: (args) => ({
+    components: { PxTag },
+    setup() {
+      return { args }
+    },
+    template: `
     <div class="px-badge-container">
       <px-tag v-bind="args" effect="light">Light</px-tag>
       <px-tag v-bind="args" effect="dark">Dark</px-tag>
       <px-tag v-bind="args" effect="plain">Plain</px-tag>
     </div>
     `
-})
-export const Disabled: StoryFn = (args) => ({
-  components: { PxTag },
-  setup() {
-    return { args }
-  },
-  template: `
+  })
+}
+
+export const Disabled: Story = {
+  render: (args) => ({
+    components: { PxTag },
+    setup() {
+      return { args }
+    },
+    template: `
     <div class="px-badge-container">
       <px-tag v-bind="args" disabled>Disabled</px-tag>
       <px-tag v-bind="args" disabled effect="dark">Disabled</px-tag>
       <px-tag v-bind="args" disabled closable>Disabled</px-tag>
     </div>
     `
-})
-export const Round: StoryFn = (args) => ({
-  components: { PxTag },
-  setup() {
-    return { args }
-  },
-  template: `
+  })
+}
+export const Round: Story = {
+  render: (args) => ({
+    components: { PxTag },
+    setup() {
+      return { args }
+    },
+    template: `
     <div class="px-badge-container">
       <px-tag v-bind="args" round>Round</px-tag>
       <px-tag v-bind="args" round effect="dark">Round</px-tag>
       <px-tag v-bind="args" round closable>Round</px-tag>
     </div>
     `
-})
-export const Circle: StoryFn = (args) => ({
-  components: { PxTag },
-  setup() {
-    return { args }
-  },
-  template: `
+  })
+}
+export const Circle: Story = {
+  render: (args) => ({
+    components: { PxTag },
+    setup() {
+      return { args }
+    },
+    template: `
     <div class="px-badge-container">
       <px-tag v-bind="args" circle>Circle</px-tag>
       <px-tag v-bind="args" circle effect="dark">Circle</px-tag>
       <px-tag v-bind="args" circle closable>Circle</px-tag>
     </div>
     `
-})
-export const Chubby: StoryFn = (args) => ({
-  components: { PxTag },
-  setup() {
-    return { args }
-  },
-  template: `
+  })
+}
+export const Chubby: Story = {
+  render: (args) => ({
+    components: { PxTag },
+    setup() {
+      return { args }
+    },
+    template: `
     <div class="px-badge-container">
       <px-tag v-bind="args" chubby>Chubby</px-tag>
       <px-tag v-bind="args" chubby effect="dark">Chubby</px-tag>
       <px-tag v-bind="args" chubby closable>Chubby</px-tag>
     </div>
     `
-})
+  })
+}

--- a/packages/docs/storybook/stories/Text/Text.stories.ts
+++ b/packages/docs/storybook/stories/Text/Text.stories.ts
@@ -1,4 +1,4 @@
-import type { Meta, StoryFn } from '@storybook/vue3'
+import type { Meta, StoryObj } from '@storybook/vue3'
 
 // import { PxText } from '@mmt817/pixel-ui'
 import { PxText } from '@pixel-ui/components'
@@ -45,13 +45,15 @@ const meta: Meta<typeof PxText> = {
 
 export default meta
 
-const Template: StoryFn = (args, { argTypes }) => ({
-  setup: () => ({ args }),
-  props: Object.keys(argTypes),
-  components: {
-    PxText
-  },
-  template: '<px-text v-bind="args">嘻嘻喵🐱mmt817喵</px-text>'
-})
+type Story = StoryObj<typeof meta>
 
-export const Text = Template.bind({})
+export const Default: Story = {
+  render: (args, { argTypes }) => ({
+    setup: () => ({ args }),
+    props: Object.keys(argTypes),
+    components: {
+      PxText
+    },
+    template: '<px-text v-bind="args">嘻嘻喵🐱mmt817喵</px-text>'
+  })
+}

--- a/packages/docs/storybook/stories/Tooltip/Tooltip.stories.ts
+++ b/packages/docs/storybook/stories/Tooltip/Tooltip.stories.ts
@@ -1,8 +1,8 @@
-import type { Meta, StoryFn } from '@storybook/vue3'
+import type { Meta, StoryObj } from '@storybook/vue3'
 import { fn } from '@storybook/test'
 import { ref } from 'vue'
 
-import { PxTooltip } from '@pixel-ui/components'
+import { PxTooltip, type TooltipProps } from '@pixel-ui/components'
 import { PxButton } from '@mmt817/pixel-ui'
 import '@mmt817/pixel-ui/dist/theme/Tooltip.css'
 import '@mmt817/pixel-ui/dist/theme/Button.css'
@@ -76,7 +76,9 @@ const meta: Meta<typeof PxTooltip> = {
 
 export default meta
 
-const Template: StoryFn = (args) => ({
+type Story = StoryObj<typeof meta>
+
+const Template = (args: TooltipProps) => ({
   components: { PxTooltip, PxButton },
   setup() {
     return { args }
@@ -90,48 +92,71 @@ const Template: StoryFn = (args) => ({
   `
 })
 
-export const Default = Template.bind({})
-Default.args = {
-  trigger: 'hover',
-  placement: 'top',
-  content: '默认提示内容'
-}
-
-export const ClickTrigger = Template.bind({})
-ClickTrigger.args = {
-  trigger: 'click',
-  placement: 'bottom',
-  content: '点击触发的提示'
-}
-
-export const ContextmenuTrigger = Template.bind({})
-ContextmenuTrigger.args = {
-  trigger: 'contextmenu',
-  placement: 'right',
-  content: '右键触发的提示'
-}
-
-export const Disabled = Template.bind({})
-Disabled.args = {
-  trigger: 'hover',
-  placement: 'top',
-  content: '禁用提示，不会显示',
-  disabled: true
-}
-
-export const ManualControl: StoryFn = (args) => ({
-  components: { PxTooltip, PxButton },
-  setup() {
-    const tooltipRef = ref()
-    const open = () => {
-      tooltipRef.value?.show()
-    }
-    const close = () => {
-      tooltipRef.value?.hide()
-    }
-    return { args, tooltipRef, open, close }
+export const Default: Story = {
+  args: {
+    trigger: 'hover',
+    placement: 'top',
+    content: '默认提示内容'
   },
-  template: `
+  render: Template
+}
+
+export const ClickTrigger: Story = {
+  args: {
+    trigger: 'click',
+    placement: 'bottom',
+    content: '点击触发的提示'
+  },
+  render: Template
+}
+
+export const ContextmenuTrigger = {
+  args: {
+    trigger: 'contextmenu',
+    placement: 'right',
+    content: '右键触发的提示'
+  },
+  render: Template
+}
+
+export const Disabled: Story = {
+  args: {
+    trigger: 'hover',
+    placement: 'top',
+    content: '禁用提示，不会显示',
+    disabled: true
+  },
+  render: Template
+}
+
+export const Effect: Story = {
+  args: {
+    trigger: 'hover',
+    content: 'dark 效果',
+    effect: 'dark'
+  },
+  render: Template
+}
+
+export const ManualControl: Story = {
+  args: {
+    manual: true,
+    content: '手动控制的提示',
+    placement: 'top'
+  },
+  render: (args) => ({
+    components: { PxTooltip, PxButton },
+    setup() {
+      const tooltipRef = ref()
+      const open = () => {
+        tooltipRef.value?.show()
+      }
+      const close = () => {
+        tooltipRef.value?.hide()
+      }
+      return { args, tooltipRef, open, close }
+    },
+    template: `
     <div style="margin: 100px; text-align: center;">
       <px-tooltip v-bind="args" ref="tooltipRef">
         <px-button>手动控制提示</px-button>
@@ -142,16 +167,5 @@ export const ManualControl: StoryFn = (args) => ({
       </div>
     </div>
   `
-})
-ManualControl.args = {
-  manual: true,
-  content: '手动控制的提示',
-  placement: 'top'
-}
-
-export const Effect = Template.bind({})
-Effect.args = {
-  trigger: 'hover',
-  content: 'dark 效果',
-  effect: 'dark'
+  })
 }


### PR DESCRIPTION
由于StoryBook中CSF格式的升级，导致在可视化界面交互时可能会出现的问题，做出类似下面的变动
CSF2中的`.stories.ts`格式
```typescript
// Replace your-framework with the framework you are using, e.g. react-vite, nextjs, nextjs-vite, etc.
import type { ComponentStory, ComponentMeta } from '@storybook/your-framework';

import { Button } from './Button';

export default {
  title: 'Button',
  component: Button,
} as ComponentMeta<typeof Button>;

export const Primary: ComponentStory<typeof Button> = (args) => <Button {...args} />;
Primary.args = { primary: true };
```

以下是CSF3中`.stories.ts`格式
```typescript
// Replace your-framework with the framework you are using, e.g. react-vite, nextjs, nextjs-vite, etc.
import type { Meta, StoryObj } from '@storybook/your-framework';

import { Button } from './Button';

const meta = {
  component: Button,
} satisfies Meta<typeof Button>;

export default meta;
type Story = StoryObj<typeof meta>;

export const Primary: Story = { args: { primary: true } };
```